### PR TITLE
WIP Urbit.Ob.unRender: Convert from Text to Atom

### DIFF
--- a/lib/Urbit/Ob/Co.hs
+++ b/lib/Urbit/Ob/Co.hs
@@ -17,6 +17,8 @@ import qualified Data.Serialize as C
 import qualified Data.Text as T
 import Data.Word (Word8, Word16, Word)
 import Urbit.Ob.Ob (fein, fynd)
+import Numeric.Natural
+import qualified Data.Vector as V
 
 newtype Patp = Patp BS.ByteString
   deriving (Eq, Show)
@@ -57,8 +59,8 @@ render (Patp p) = prefixed where
 
   encoded = foldr alg mempty pruned where
     alg (idx, x) acc
-      | odd idx   =        grab (IMS.lookup (fromIntegral x) suffixes) <> acc
-      | otherwise = "-" <> grab (IMS.lookup (fromIntegral x) prefixes) <> acc
+      | odd idx   =        grab (V.unsafeIndex (fromIntegral x) suffixes) <> acc
+      | otherwise = "-" <> grab (V.unsafeIndex (fromIntegral x) prefixes) <> acc
 
   pruned =
     let len = BS.length p
@@ -66,8 +68,8 @@ render (Patp p) = prefixed where
         padding (idx, val) = idx /= 1 && val == 0
     in  dropWhile padding indexed
 
-prefixes :: IMS.IntMap T.Text
-prefixes = IMS.fromList $ zip [0..]
+prefixes :: V.Vector T.Text
+prefixes = V.fromList
   ["doz","mar","bin","wan","sam","lit","sig","hid","fid","lis","sog","dir"
   ,"wac","sab","wis","sib","rig","sol","dop","mod","fog","lid","hop","dar"
   ,"dor","lor","hod","fol","rin","tog","sil","mir","hol","pas","lac","rov"
@@ -91,8 +93,8 @@ prefixes = IMS.fromList $ zip [0..]
   ,"lap","tal","pit","nam","bon","ros","ton","fod","pon","sov","noc","sor"
   ,"lav","mat","mip","fip"]
 
-suffixes :: IMS.IntMap T.Text
-suffixes = IMS.fromList $ zip [0..]
+suffixes :: V.Vector T.Text
+suffixes = V.fromList
   ["zod","nec","bud","wes","sev","per","sut","let","ful","pen","syt","dur"
   ,"wep","ser","wyl","sun","ryp","syx","dyr","nup","heb","peg","lup","dep"
   ,"dys","put","lug","hec","ryt","tyv","syd","nex","lun","mep","lut","sep"

--- a/urbit-hob.cabal
+++ b/urbit-hob.cabal
@@ -63,6 +63,7 @@ library
     , containers  >= 0.5  && < 1
     , murmur3     >= 1.0  && < 2
     , text        >= 1.2  && < 2
+    , vector      >= 0.12 && < 0.13
 
 Test-suite small
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
I need to convert from text to `@p`. Implemented that, but there are some error cases that I don't understand yet.

```
*Urbit.Ob.Co> failures
[110735,118399,180443,189274,271931,326625,364207,401619,438796,545211^CInterrupted.
```